### PR TITLE
fix: 랭킹보드/생성페이지 반응형으로 css수정

### DIFF
--- a/src/components/createpage/CreateTimeTable.jsx
+++ b/src/components/createpage/CreateTimeTable.jsx
@@ -3,17 +3,20 @@ import Hamburger from '../_common/Hamburger';
 import TimeTable from '../createpage/TimeTable';
 import TimeTableInput from '../createpage/TimeTableInput';
 
+//페이지
 const CreateTimeTable = () => {
     return (
-        <>
-            <S.Wrapper>
-                <Hamburger />
-                <S.Container>
+        <S.Wrapper>
+            <Hamburger />
+            <S.Container>
+                <S.SmallContainer>
                     <TimeTable />
+                </S.SmallContainer>
+                <S.SmallContainer>
                     <TimeTableInput />
-                </S.Container>
-            </S.Wrapper>
-        </>
+                </S.SmallContainer>
+            </S.Container>
+        </S.Wrapper>
     );
 };
 

--- a/src/components/createpage/CreateTimeTable.style.js
+++ b/src/components/createpage/CreateTimeTable.style.js
@@ -32,8 +32,18 @@ S.Container = styled(S.BasicContainer)`
     height: 70%;
     border: 0.1rem solid black;
     background: linear-gradient(180deg, #b0ff00 0%, #e2e2e2 100%);
-    
     display: flex;
-    justify-content: space-evenly;
+    align-items: center;
+    justify-content: center;
+`;
+
+S.SmallContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 49.5%;
+    height: 100%;
+    overflow-y: scroll;
 `;
 export { S };

--- a/src/components/createpage/TimeTable.jsx
+++ b/src/components/createpage/TimeTable.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-
 // props로 초기화 버튼 null 처리하기
 const TimeTable = () => {
     const startHour = 8;
@@ -19,7 +18,6 @@ const TimeTable = () => {
 
     return (
         <div style={{ position: 'relative' }}>
-            <ResetBtn>초기화</ResetBtn>
             <TimeTableContainer>
                 <table>
                     <thead>
@@ -30,7 +28,7 @@ const TimeTable = () => {
                             ))}
                         </tr>
                     </thead>
-                    <tbody style={{backgroundColor: "white"}}>
+                    <tbody style={{ backgroundColor: 'white' }}>
                         {timeSlots.map((timeSlot, index) => (
                             <tr key={timeSlot}>
                                 <TimeCell>{timeSlot}</TimeCell>
@@ -53,8 +51,8 @@ const TimeTable = () => {
 export default TimeTable;
 
 const TimeTableContainer = styled.div`
-    width: 20.54rem;
-    height: 22.1575rem;
+    width: 100%;
+    height: 100%;
 
     border-radius: 0.4rem;
     border: 0.08rem solid var(--black);
@@ -104,6 +102,9 @@ const TableCell = styled.td`
     }
 
     border-radius: ${({ isFirst, isLast }) =>
-        isFirst ? '0.5625rem 0.5625rem 0 0' : isLast ? '0 0 0.5625rem 0.5625rem' : 'none'};
-
+        isFirst
+            ? '0.5625rem 0.5625rem 0 0'
+            : isLast
+            ? '0 0 0.5625rem 0.5625rem'
+            : 'none'};
 `;

--- a/src/components/createpage/TimeTableInput.jsx
+++ b/src/components/createpage/TimeTableInput.jsx
@@ -21,6 +21,7 @@ const TimeTableInput = () => {
     ];
     // 강의 장소 배열
     const coursePlace = [
+        '원격/비대면',
         'ECC',
         '공학관',
         '교육관',
@@ -41,7 +42,6 @@ const TimeTableInput = () => {
         '음악관',
         '종합과학관',
         '포스코관',
-        '원격/비대면',
     ];
 
     // dropdown 4개 open 여부 (요일, 시작시간, 끝시간, 장소)
@@ -85,20 +85,22 @@ const TimeTableInput = () => {
     return (
         <>
             <S.InputContainer>
-                <S.ButtonDiv>
-                    <S.LectureButton bgcolor='#F22B02'>
-                        강의 삭제
-                    </S.LectureButton>
-                    <S.LectureButton bgcolor='#1962ED'>
-                        강의 추가
-                    </S.LectureButton>
-                </S.ButtonDiv>
+                <S.InputDiv>
+                    <S.ButtonDiv>
+                        <S.LectureButton bgcolor='#F22B02'>
+                            강의 삭제
+                        </S.LectureButton>
+                        <S.LectureButton bgcolor='#1962ED'>
+                            강의 추가
+                        </S.LectureButton>
+                    </S.ButtonDiv>
+                </S.InputDiv>
 
                 <S.InputDiv>
-                    <div style={{ display: 'flex' }}>
+                    <S.InputText>
                         <S.MainText>강의시간</S.MainText>
                         <S.RedCircle />
-                    </div>
+                    </S.InputText>
                     <S.DescDiv style={{ zIndex: '20' }}>
                         {/* 요일 dropdown */}
                         <S.DayDropdownDiv isopen={isOpen[0]}>
@@ -125,7 +127,9 @@ const TimeTableInput = () => {
                                                   changeContent(0, 'day', day)
                                               }
                                           >
-                                              <S.DescDayText>{day}</S.DescDayText>
+                                              <S.DescDayText>
+                                                  {day}
+                                              </S.DescDayText>
                                           </div>
                                       );
                                   })
@@ -142,7 +146,9 @@ const TimeTableInput = () => {
                                 }}
                                 onClick={() => changeOpen(1, true)}
                             >
-                                <S.DescTimeText>{selectedStartTime}</S.DescTimeText>
+                                <S.DescTimeText>
+                                    {selectedStartTime}
+                                </S.DescTimeText>
                                 <S.DownIcon
                                     src={ic_dropdown}
                                     isopen={isOpen[1]}
@@ -161,7 +167,9 @@ const TimeTableInput = () => {
                                                   )
                                               }
                                           >
-                                              <S.DescTimeText>{time}</S.DescTimeText>
+                                              <S.DescTimeText>
+                                                  {time}
+                                              </S.DescTimeText>
                                           </div>
                                       );
                                   })
@@ -178,7 +186,9 @@ const TimeTableInput = () => {
                                 }}
                                 onClick={() => changeOpen(2, true)}
                             >
-                                <S.DescTimeText>{selectedEndTime}</S.DescTimeText>
+                                <S.DescTimeText>
+                                    {selectedEndTime}
+                                </S.DescTimeText>
                                 <S.DownIcon
                                     src={ic_dropdown}
                                     isopen={isOpen[2]}
@@ -190,14 +200,12 @@ const TimeTableInput = () => {
                                       return (
                                           <div
                                               onClick={() =>
-                                                  changeContent(
-                                                      2,
-                                                      'end',
-                                                      time,
-                                                  )
+                                                  changeContent(2, 'end', time)
                                               }
                                           >
-                                              <S.DescTimeText>{time}</S.DescTimeText>
+                                              <S.DescTimeText>
+                                                  {time}
+                                              </S.DescTimeText>
                                           </div>
                                       );
                                   })
@@ -211,55 +219,64 @@ const TimeTableInput = () => {
                 </S.ButtonDiv>
 
                 <S.InputDiv>
-                    <div style={{ display: 'flex' }}>
+                    <S.InputText>
                         <S.MainText>강의장소</S.MainText>
                         <S.RedCircle />
-                    </div>
-                    <S.DescDiv>
-                        <S.DropdownDiv isopen={isOpen[3]}>
-                            <div
-                                style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                }}
-                                onClick={() => changeOpen(3, true)}
-                            >
-                                <S.DescPlaceText>{selectedPlace}</S.DescPlaceText>
-                                <S.DownIcon
-                                    src={ic_dropdown}
-                                    isopen={isOpen[3]}
-                                    alt='dropdown버튼'
-                                />
-                            </div>
-                            {isOpen[3] === true
-                                ? coursePlace.map((place, _) => {
-                                      return (
-                                          <div
-                                              onClick={() =>
-                                                  changeContent(
-                                                      3,
-                                                      'where',
-                                                      place,
-                                                  )
-                                              }
-                                          >
-                                              <S.DescPlaceText>{place}</S.DescPlaceText>
-                                          </div>
-                                      );
-                                  })
-                                : null}
-                        </S.DropdownDiv>
-                    </S.DescDiv>
+                    </S.InputText>
+                    <S.InputBox>
+                        <S.DescDiv>
+                            <S.DropdownDiv isopen={isOpen[3]}>
+                                <div
+                                    style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'space-between',
+                                    }}
+                                    onClick={() => changeOpen(3, true)}
+                                >
+                                    <S.DescPlaceText>
+                                        {selectedPlace}
+                                    </S.DescPlaceText>
+                                    <S.DownIcon
+                                        src={ic_dropdown}
+                                        isopen={isOpen[3]}
+                                        alt='dropdown버튼'
+                                    />
+                                </div>
+                                {isOpen[3] === true
+                                    ? coursePlace.map((place, _) => {
+                                          return (
+                                              <div
+                                                  onClick={() =>
+                                                      changeContent(
+                                                          3,
+                                                          'where',
+                                                          place,
+                                                      )
+                                                  }
+                                              >
+                                                  <S.DescPlaceText>
+                                                      {place}
+                                                  </S.DescPlaceText>
+                                              </div>
+                                          );
+                                      })
+                                    : null}
+                            </S.DropdownDiv>
+                        </S.DescDiv>
+                    </S.InputBox>
                 </S.InputDiv>
 
                 <S.InputDiv>
-                    <S.MainText style={{ width: '3.988rem' }}>
-                        강의명
-                    </S.MainText>
-                    <S.NameInput placeholder='강의명을 입력하세요' />
+                    <S.InputText>
+                        <S.MainText style={{ width: '3.988rem' }}>
+                            강의명
+                        </S.MainText>
+                    </S.InputText>
+                    <S.InputBox>
+                        <S.NameInput placeholder='강의명을 입력하세요' />
+                    </S.InputBox>
                 </S.InputDiv>
-
                 <S.CompleteBtn>시간표 완성</S.CompleteBtn>
             </S.InputContainer>
         </>

--- a/src/components/createpage/TimeTableInput.style.js
+++ b/src/components/createpage/TimeTableInput.style.js
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 const S = {};
 
 S.InputContainer = styled.div`
-    display: flex;
     flex-direction: column;
-    align-items: flex-end;
+    height: 100%;
+    width: 100%;
 `;
 
 S.MainText = styled.div`
@@ -34,21 +34,23 @@ S.DescPlaceText = styled(S.DescText)`
 `;
 
 S.LectureButton = styled.button`
-    width: 5.2rem;
-    height: 1.9rem;
+    width: 45%;
+    height: 2rem;
     padding: 0.25rem 0.75rem;
     background-color: ${props => props.bgcolor};
     border-radius: 19px;
     border: 0.08rem solid var(--black);
 
     font-family: Gothic A1;
-    font-size: 13px;
+    font-size: 0.7rem;
     font-weight: 500;
     color: white;
 `;
 
 S.ButtonDiv = styled.div`
-    width: 14.45rem;
+    margin-left: 30%;
+    margin-top: 5%;
+    width: 50%;
     display: flex;
     justify-content: space-between;
 `;
@@ -58,11 +60,12 @@ S.InputDiv = styled.div`
     align-items: center;
     gap: 1.648rem;
 
-    margin-top: 25.6px;
+    margin-top: 5%;
+    padding-left: 5%;
 `;
 
 S.DescDiv = styled.div`
-    width: 14.45rem;
+    width: 60%;
     height: 2rem;
     z-index: 10;
 
@@ -86,7 +89,7 @@ S.TimeDropdownDiv = styled(S.DayDropdownDiv)`
 `;
 
 S.DropdownDiv = styled.div`
-    width: 14.45rem;
+    width: 10rem;
     height: ${props => (props.isopen ? '10rem' : '2rem')};
 
     border-radius: ${props => (props.isopen ? '18px' : '28px')};
@@ -97,7 +100,6 @@ S.DropdownDiv = styled.div`
 `;
 
 S.NameInput = styled.input`
-    width: 14.45rem;
     height: 2rem;
 
     border-radius: 28px;
@@ -124,19 +126,19 @@ S.DownIcon = styled.img`
 `;
 
 S.CompleteBtn = styled.button`
-    width: 16.5rem;
-    height: 4rem;
+    margin-left: 30%;
+    width: 40%;
+    height: 15%;
 
     border-radius: 17.6px;
     border: 0.08rem solid var(--black);
     background-color: #b0ff00;
 
     font-family: Gothic A1;
-    font-size: 20px;
+    font-size: 1.2rem;
     font-weight: 600;
     line-height: normal;
-
-    margin-top: 2.304rem;
+    margin-top: 5%;
 `;
 
 S.RedCircle = styled.div`
@@ -144,9 +146,15 @@ S.RedCircle = styled.div`
     height: 0.35rem;
     border-radius: 50%;
     background-color: red;
-
     margin-left: 0.4rem;
     margin-top: -0.64rem;
 `;
 
+S.InputText = styled.div`
+    width: 20%;
+    display: flex;
+`;
+S.InputBox = styled.div`
+    width: 70%;
+`;
 export { S };

--- a/src/components/rankingpage/Rank.jsx
+++ b/src/components/rankingpage/Rank.jsx
@@ -21,7 +21,7 @@ const Rank = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const rankList = useSelector(state => state.rankReducer);
     const [currentUser, setCurrentUser] = useState();
-    const currentId = searchParams.get('id') || 1;
+    const currentId = searchParams.get('id') || rankList[0].id;
 
     //현재 선택한 유저의 id와 일치하는 데이터를 찾아서 보여주기
     useEffect(() => {
@@ -46,10 +46,11 @@ const Rank = () => {
                     <RankingList></RankingList>
                 </S.SmallContainer>
                 {/*개별 유저 데이터 보여주는 right section*/}
-                <S.SmallContainer>
-                    <RankUserInfo currentUser={currentUser} />
-                    {/*🧐자의로 추가한 부분 : 유저 닉네임*/}
-                    {/* {currentUser && (
+                {currentUser && (
+                    <S.SmallContainer>
+                        <RankUserInfo currentUser={currentUser} />
+                        {/*🧐자의로 추가한 부분 : 유저 닉네임*/}
+                        {/* {currentUser && (
                         <S.OneUserNameContainer>
                             <S.OneUserName>
                                 {currentUser?.nickname}
@@ -57,24 +58,25 @@ const Rank = () => {
                             <S.TimeTableText>님의 시간표</S.TimeTableText>
                         </S.OneUserNameContainer>
                     )} */}
-                    <S.BedgeContainer>
-                        {<S.Bedge2>{currentUser?.category}</S.Bedge2>}
-                    </S.BedgeContainer>
-                    <S.TimeTable src={TimeTableImg} alt='사진' />
-                    {/*버튼 컨테이너*/}
-                    <S.ButtonContainer>
-                        <S.IconButton>
-                            <S.Icon src={NoLike} alt='하트' />
-                            11
-                        </S.IconButton>
-                        <S.IconButton>
-                            <S.Icon src={Comment} alt='댓글' />
-                            11
-                        </S.IconButton>
-                    </S.ButtonContainer>
-                    <NewComment />
-                    <CommentList />
-                </S.SmallContainer>
+                        <S.BedgeContainer>
+                            {<S.Bedge2>{currentUser?.category}</S.Bedge2>}
+                        </S.BedgeContainer>
+                        <S.TimeTable src={TimeTableImg} alt='사진' />
+                        {/*버튼 컨테이너*/}
+                        <S.ButtonContainer>
+                            <S.IconButton>
+                                <S.Icon src={NoLike} alt='하트' />
+                                11
+                            </S.IconButton>
+                            <S.IconButton>
+                                <S.Icon src={Comment} alt='댓글' />
+                                11
+                            </S.IconButton>
+                        </S.ButtonContainer>
+                        <NewComment />
+                        <CommentList />
+                    </S.SmallContainer>
+                )}
             </S.Container>
         </S.Wrapper>
     );

--- a/src/components/rankingpage/Ranking.style.js
+++ b/src/components/rankingpage/Ranking.style.js
@@ -44,30 +44,31 @@ S.SmallContainer = styled.div`
 `;
 
 S.Header = styled.div`
-    margin-top: 1.7rem;
+    margin-top: 7%;
+    height: 20%;
+    display: block;
 `;
 
 S.NewButton = styled.div`
-    margin-top: 1rem;
-    width: 12.13rem;
-    height: 2.8rem;
+    width: 140%;
+    margin-left: -20%;
+    padding: 10% 10% 10% 10%;
     border: 0.1rem solid var(--blue);
     font-weight: 500;
     ${FlexCenter}
     color: var(--blue);
     border-radius: 44px;
     background-color: var(--green);
-    text-align: center;
-    font-size: 1.1rem;
+    font-size: 0.9rem;
 `;
 
 //rank
 S.RankNum = styled.div`
-    width: 3.9rem;
-    height: 3.9rem;
+    width: 60px;
+    height: 50px;
     border-radius: 50%;
     ${FlexCenter}
-    font-size: 2.7rem;
+    font-size: 1.8rem;
     font-weight: 700;
     font-family: Montserrat;
     background-color: ${({ isCurrentUser }) =>
@@ -77,37 +78,25 @@ S.RankNum = styled.div`
         ${({ isCurrentUser }) => (isCurrentUser ? 'var(--blue)' : 'black')};
 `;
 
-S.RankNumCurrent = styled.div`
-    width: 3.9rem;
-    height: 3.9rem;
-    border-radius: 50%;
-    border: 0.1rem solid black;
-    ${FlexCenter}
-    font-size: 3rem;
-    font-weight: 700;
-    font-family: Montserrat;
-    background-color: pink;
-`;
-
 S.UserInfo = styled.div`
-    width: 18.6rem;
-    height: 3.8rem;
+    width: 100%;
+    height: 100%;
     background-color: ${({ isCurrentUser }) =>
         isCurrentUser ? 'var(--green)' : 'white'};
     border: 0.1rem solid black;
     border-radius: 60px;
     ${FlexCenter}
-    position:relative;
+    position: relative;
     color: ${({ isCurrentUser }) => (isCurrentUser ? 'var(--blue)' : 'black')};
     border: 0.1rem solid
         ${({ isCurrentUser }) => (isCurrentUser ? 'var(--blue)' : 'black')};
-    font-size: 1.25rem;
+    font-size: 1rem;
 `;
 
 S.RankContainer = styled.div`
     font-family: Montserrat;
-    width: 22.8rem;
-    margin-top: 1.2rem;
+    width: 100%;
+    margin-top: 10%;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -115,15 +104,16 @@ S.RankContainer = styled.div`
 
 //탭 css
 S.TabContainer = styled.div`
-    margin-top: 1.7rem;
-    height: 2.3rem;
+    margin-top: 10%;
+    height: 15%;
+    width: 75%;
     ${FlexCenter};
 `;
 
 S.Tab = styled.div`
-    width: 12.3rem;
-    height: 1.65rem;
-    font-size: 0.9rem;
+    width: 50%;
+    padding-bottom: 3%;
+    font-size: 0.8rem;
     font-weight: 500;
     ${FlexCenter};
     border-bottom: ${({ active }) =>
@@ -134,9 +124,8 @@ S.Tab = styled.div`
 //토글 css
 S.ToggleContainer = styled.div`
     ${FlexCenter}
-    margin-top: 1.7rem;
-    margin-left: -10rem;
-    margin-bottom: 1rem;
+    margin-top: 10%;
+    margin-left: -30%;
 `;
 
 S.ToggleButton = styled.div`
@@ -164,7 +153,7 @@ S.Slider = styled.div`
 `;
 
 S.ToggleText = styled.div`
-    font-size: 1rem;
+    font-size: 0.7rem;
     margin-left: 10px;
     color: black;
 `;
@@ -187,7 +176,8 @@ S.TextBox = styled.div`
 S.List = styled.div`
     ${FlexCenter}
     flex-direction:column;
-    margin-bottom: 2rem;
+    margin-bottom: 10%;
+    width: 75%;
 `;
 
 //rightSection : 개별 유저 section
@@ -219,16 +209,15 @@ S.List = styled.div`
 
 S.RankUserContainer = styled.div`
     font-family: Montserrat;
-    height: 60.588px;
     ${FlexCenter}
-    margin-top:32px;
-    width: 361px;
+    margin-top:10%;
+    width: 70%;
     justify-content: space-between;
 `;
 
 S.NameContainer = styled.div`
     position: absolute;
-    left: 20px;
+    left: 10%;
 `;
 
 S.Score = styled.div`
@@ -236,30 +225,29 @@ S.Score = styled.div`
 `;
 
 S.NameText = styled.div`
-    font-size: 12px;
+    font-size: 0.6rem;
 `;
 
 S.Category = styled.div`
-    width: 180px;
     position: absolute;
-    left: 70px;
+    display: block;
+    left: 30%;
+    padding-right: 2%;
+    font-size: 0.9rem;
 `;
 
 //버튼 컨테이너
 S.ButtonContainer = styled.div`
-    width: 200px
-    height: 25px;
+    width: 75%;
     border-radius: 5px;
-    display:flex;
-    position:relative;
-    left:-100px;
-    margin-top:1.5rem;
-
+    display: flex;
+    position: relative;
+    margin-top: 1.2rem;
 `;
 
 S.IconButton = styled.button`
-    width: 55px;
-    height: 25px;
+    width: 18%;
+    height: 100%;
     background-color: var(--red);
     border-radius: 5px;
     display: flex;
@@ -279,8 +267,6 @@ S.Icon = styled.img`
 
 //댓글
 S.OneCommentContainer = styled.div`
-    width: 320px;
-    height: 100px;
     background-color: var(--green);
     border-radius: 7px;
     border: 0.1rem solid black;
@@ -297,17 +283,22 @@ S.CommentInfo = styled.div`
 
 S.CommentUserName = styled.div`
     padding-right: 0.5rem;
+    font-size: 0.9rem;
     font-weight: 600;
 `;
 
-S.CommentDate = styled.div``;
+S.CommentDate = styled.div`
+    font-size: 0.8rem;
+`;
 
-S.CommentText = styled.div``;
+S.CommentText = styled.div`
+    font-size: 0.9rem;
+`;
 
 //시간표 목업 사진
 S.TimeTable = styled.img`
-    width: 358px;
-    height: 385px;
+    width: 75%;
+    height: 75%;
     background-color: #888;
     border: 1px solid black;
     margin-top: 0.8rem;
@@ -315,8 +306,8 @@ S.TimeTable = styled.img`
 
 //댓글 쓰기 컴포넌트
 S.NewCommentWrapper = styled.div`
-    margin-top: 1rem;
-    width: 20.25rem;
+    margin-top: 5%;
+    width: 75%;
     font-size: 1.2vw;
     padding: 0.5rem 0.5rem;
     border-radius: 2rem;
@@ -334,13 +325,13 @@ S.CommentInput = styled.textarea`
 `;
 
 S.UploadImg = styled.img`
-    width: 1.8rem;
-    height: 1.8rem;
+    width: 1.5rem;
+    height: 1.5rem;
     margin-left: 20px;
 `;
 
 S.OneUserName = styled.div`
-    font-size: 1.4rem;
+    font-size: 1.2rem;
     font-weight: 500;
     color: var(--blue);
     margin-top: 0.8rem;

--- a/src/components/rankingpage/leftSection/RankingList.jsx
+++ b/src/components/rankingpage/leftSection/RankingList.jsx
@@ -25,7 +25,7 @@ const RankingList = () => {
             {/*최악, 최고의 시간표일 때만 토글을 보여줌*/}
             {sort === 'popular' ? null : <Toggle />}
             {rankList.map((user, index) => {
-                return <OneRanking data={user} index={index} />;
+                return <OneRanking key={user.id} data={user} index={index} />;
             })}
         </S.List>
     );

--- a/src/components/rankingpage/rightSection/CommentList.jsx
+++ b/src/components/rankingpage/rightSection/CommentList.jsx
@@ -12,6 +12,6 @@ const CommentList = () => {
 export default CommentList;
 
 const CommentContainer = styled.div`
-    margin-top: 1rem;
-    margin-bottom: 1rem;
+    margin-top: 5%;
+    width: 75%;
 `;

--- a/src/components/rankingpage/rightSection/RankUserInfo.jsx
+++ b/src/components/rankingpage/rightSection/RankUserInfo.jsx
@@ -3,18 +3,16 @@ import S from '../Ranking.style';
 const RankUserInfo = ({ currentUser }) => {
     const isCurrentUser = true;
     return (
-        currentUser && (
-            <S.RankUserContainer>
-                <S.RankNum isCurrentUser={isCurrentUser}>1</S.RankNum>
-                <S.UserInfo isCurrentUser={isCurrentUser}>
-                    <S.NameContainer>
-                        <S.NameText>{currentUser.name}</S.NameText>
-                        <S.Score>{currentUser.score}</S.Score>
-                    </S.NameContainer>
-                    <S.RankUserName>{currentUser.nickname}</S.RankUserName>
-                </S.UserInfo>
-            </S.RankUserContainer>
-        )
+        <S.RankUserContainer>
+            <S.RankNum isCurrentUser={isCurrentUser}>1</S.RankNum>
+            <S.UserInfo isCurrentUser={isCurrentUser}>
+                <S.NameContainer>
+                    <S.NameText>{currentUser.name}</S.NameText>
+                    <S.Score>{currentUser.score}</S.Score>
+                </S.NameContainer>
+                <S.RankUserName>{currentUser.nickname}</S.RankUserName>
+            </S.UserInfo>
+        </S.RankUserContainer>
     );
 };
 export default RankUserInfo;

--- a/src/components/scorepage/Score.jsx
+++ b/src/components/scorepage/Score.jsx
@@ -12,7 +12,6 @@ const Score = () => {
     return (
         <S.Wrapper>
             {/*햄버거*/}
-            {/* <S.Hamburger /> */}
             <Hamburger />
             <S.Container>
                 {data.length !== 0 ? (


### PR DESCRIPTION
## Summary

### 작업한 페이지명

랭킹보드 페이지와 시간표 생성 페이지의 css를 반응형 %단위로 수정했습니다. 

## To Reviewers
<img width="372" alt="스크린샷 2023-07-12 오후 12 35 46" src="https://github.com/SamwaMoney/Time-Table-Artist-front/assets/125418818/d18ddeaa-0fc2-41ee-b6ff-31bcc3e58579">
<br/>
수정하는 과정에서 input창을 열때 밑의 인풋창의 뒤로 들어가는 에러가 생겼습니다. 해당페이지는 디자인 리팩토링이 필요하므로 그 때 수정하는게 좋을 것 같습니다!

