### PR TITLE
fix: 시간표 강의 추가 페이지 모바일 ui 수정

### DIFF
--- a/src/components/createpage/M_CreateTimeTable.style.js
+++ b/src/components/createpage/M_CreateTimeTable.style.js
@@ -107,10 +107,10 @@ S.PlacePickerWrapper = styled.div`
     z-index:200;
     position: fixed;
     bottom: 0;
-    background-color:var(--background)
-    height:20vw;
-    display:flex;
-    flex-direction:column;
+    background-color:var(--background);
+    height: 20vw;
+    display: flex;
+    flex-direction: column;
 
     div {
         font-weight: 500;
@@ -173,7 +173,7 @@ S.SelectedContainer = styled.div`
 `;
 
 S.MPickerSmallBtn = styled.button`
-    margin-left: 20vw;
+    /* margin-left: 20vw; */
     margin-top: 4vw;
     width: 18vw;
     height: 8vw;
@@ -202,5 +202,7 @@ S.PickerBtnWrapper = styled.div`
     position: fixed;
     left: 0;
     z-index: 2000;
+    display: flex;
+    justify-content: space-around;
 `;
 export { S };

--- a/src/components/createpage/M_PlacePicker.jsx
+++ b/src/components/createpage/M_PlacePicker.jsx
@@ -52,7 +52,18 @@ const PlacePicker = ({
                 <S.SelectedContainer />
                 <Swiper {...PickerOptions} onSlideChange={onChangeDay}>
                     {COURSE_PLACE.map((place, index) => (
-                        <SwiperSlide key={index}>{place}</SwiperSlide>
+                        <SwiperSlide
+                            key={index}
+                            style={{
+                                textAlign: 'center',
+                                color:
+                                    selectedPlaceIndex === index
+                                        ? 'black'
+                                        : 'gray',
+                            }}
+                        >
+                            {place}
+                        </SwiperSlide>
                     ))}
                 </Swiper>
             </S.PickerWrapper>

--- a/src/components/createpage/M_TimePicker.jsx
+++ b/src/components/createpage/M_TimePicker.jsx
@@ -78,7 +78,16 @@ const TimePicker = ({
                 <S.SelectedContainer />
                 <Swiper {...PickerOptions} onSlideChange={onChangeDay}>
                     {DAYS_OF_WEEK.map((day, index) => (
-                        <SwiperSlide key={index}>
+                        <SwiperSlide
+                            key={index}
+                            style={{
+                                textAlign: 'center',
+                                color:
+                                    selectedDayIndex === index
+                                        ? 'black'
+                                        : 'gray',
+                            }}
+                        >
                             <div
                                 style={{
                                     fontSize: '5vw',
@@ -91,7 +100,16 @@ const TimePicker = ({
                 </Swiper>
                 <Swiper {...PickerOptions} onSlideChange={onChangeStartTime}>
                     {COURSE_TIME.map((time, index) => (
-                        <SwiperSlide key={index}>
+                        <SwiperSlide
+                            key={index}
+                            style={{
+                                textAlign: 'center',
+                                color:
+                                    selectedTimeStartIndex === index
+                                        ? 'black'
+                                        : 'gray',
+                            }}
+                        >
                             <div
                                 style={{
                                     fontSize: '5vw',
@@ -104,7 +122,16 @@ const TimePicker = ({
                 </Swiper>
                 <Swiper {...PickerOptions} onSlideChange={onChangeEndTime}>
                     {COURSE_TIME.map((time, index) => (
-                        <SwiperSlide key={index}>
+                        <SwiperSlide
+                            key={index}
+                            style={{
+                                textAlign: 'center',
+                                color:
+                                    selectedTimeEndIndex === index
+                                        ? 'black'
+                                        : 'gray',
+                            }}
+                        >
                             {' '}
                             <div
                                 style={{

--- a/src/components/createpage/M_TimeTableInputModal.jsx
+++ b/src/components/createpage/M_TimeTableInputModal.jsx
@@ -4,7 +4,7 @@ import ic_x from '../../assets/createpage/ic_x.png';
 import add_course_mobile from '../../assets/createpage/add_course_mobile.png';
 import TimePicker from './M_TimePicker';
 import PlacePicker from './M_PlacePicker';
-import { AiOutlineMinus } from 'react-icons/ai';
+import subtract_course from '../../assets/createpage/subtract_course.png';
 import { useDispatch } from 'react-redux';
 import { addSelectedData } from '../../reducer/action';
 
@@ -154,7 +154,7 @@ const MTimeTableInputModal = ({ isModalOpen, setIsModalOpen }) => {
                                 </S.MTimeInput>
                                 {/*두번째 인풋 창을 열면 새로운 시간 인풋창이 생성*/}
                                 {!isSecondTimeInputOpen ? (
-                                    <div>
+                                    <>
                                         <S.MAddButtonDiv>
                                             <S.MAddButton
                                                 src={add_course_mobile}
@@ -176,13 +176,12 @@ const MTimeTableInputModal = ({ isModalOpen, setIsModalOpen }) => {
                                                 </S.MCheckBoxText>
                                             </S.MCheckBoxDiv>
                                         </S.MAddButtonDiv>
-                                    </div>
+                                    </>
                                 ) : (
                                     <div
                                         style={{
-                                            paddingTop: '2vw',
+                                            paddingTop: '1.7vh',
                                             display: 'flex',
-                                            width: '55vw',
                                         }}
                                     >
                                         {plusSelectedDateTime && (
@@ -211,14 +210,9 @@ const MTimeTableInputModal = ({ isModalOpen, setIsModalOpen }) => {
                                                 </div>
                                             </S.MTimeInput>
                                         )}
-                                        {/*시간 빼기 버튼*/}
-                                        <AiOutlineMinus
-                                            size={'7vw'}
-                                            color={'red'}
-                                            style={{
-                                                position: 'absolute',
-                                                right: '6vw',
-                                            }}
+                                        <S.MinusBtn
+                                            src={subtract_course}
+                                            alt='-버튼'
                                             onClick={onCloseTimeInput}
                                         />
                                     </div>

--- a/src/components/createpage/M_TimeTableInputModal.style.js
+++ b/src/components/createpage/M_TimeTableInputModal.style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const S = {};
 
 const INPUTWIDTH = 65;
-const INPUTHEIGHT = 2.4;
+const INPUTHEIGHT = 2.2;
 const FONTBASICSIZE = 3.5;
 
 S.MModalContainer = styled.div`
@@ -126,15 +126,14 @@ S.MPlaceInput = styled.div`
 `;
 
 S.MTimeInputDiv = styled.div`
-    width: 50vw;
+    width: 65%;
 `;
 
 S.MTimeInput = styled(S.MPlaceInput)`
-    margin-left: 6vw;
-    padding: 0 14%;
+    padding: 0 20%;
     justify-content: space-between;
-    /* width: 100%; */
-    width: 44vw;
+    width: 100%;
+    /* width: 44vw; */
 
     &.ischecked {
         pointer-events: none;
@@ -163,11 +162,11 @@ S.MAddButtonDiv = styled.div`
     display: flex;
     justify-content: space-between;
 
-    margin-top: 6%;
+    margin-top: 7.5%;
 `;
 
 S.MAddButton = styled.img`
-    width: 17%;
+    width: 20%;
     cursor: pointer;
 
     &.ischecked {
@@ -209,6 +208,12 @@ S.MCompleteButton = styled.button`
     border: 0.05rem solid var(--black, #171717);
     border-radius: 100px;
     background-color: var(--blue, #1962ed);
+`;
+
+S.MinusBtn = styled.img`
+    width: ${INPUTHEIGHT}rem;
+    position: absolute;
+    cursor: pointer;
 `;
 
 export { S };


### PR DESCRIPTION
## Summary

### createpage 모바일

-   페이지 전체적으로 정렬이 맞지 않는 부분 수정
-  -버튼 피그마에 있는대로 수정
![image](https://github.com/SamwaMoney/Time-Table-Artist-front/assets/81233784/d99e8f3a-3722-4597-a758-bc795d0c6eba)

-  picker ui 선택된 요소만 검정색, 나머지 요소는 회색으로 보이도록 수정
![image](https://github.com/SamwaMoney/Time-Table-Artist-front/assets/81233784/e7e91835-1976-4f29-b164-0803ac6bef43)

## To Reviewers

-   오늘 밤~내일 새벽까지 시간표 강의 추가 기능 보완, 강의 삭제 기능 구현하겠습니다.
